### PR TITLE
Add missing features for probes and context operations

### DIFF
--- a/semantic_framework/context_operations/context_observer.py
+++ b/semantic_framework/context_operations/context_observer.py
@@ -1,3 +1,7 @@
+from typing import Any
+from .context_types import ContextType
+
+
 class ContextObserver:
     """
     Class for managing and observing context updates within the semantic framework.
@@ -13,9 +17,9 @@ class ContextObserver:
         Attributes:
             context (dict): A dictionary to store contextual key-value pairs.
         """
-        self.context = {}
+        self.observer_context = ContextType
 
-    def update_context(self, key: str, value: any):
+    def update_context(self, key: str, value: Any):
         """
         Update the context with a new key-value pair or modify an existing one.
 
@@ -23,35 +27,7 @@ class ContextObserver:
             key (str): The key associated with the context value.
             value (any): The value to be stored in the context.
         """
-        self.context[key] = value
-
-    def get_context_value(self, key: str):
-        """
-        Retrieve the value associated with a given key in the context.
-
-        Args:
-            key (str): The key to look up in the context.
-
-        Returns:
-            any: The value associated with the key, or None if the key does not exist.
-        """
-        return self.context.get(key)
-
-    def remove_context_key(self, key: str):
-        """
-        Remove a key-value pair from the context.
-
-        Args:
-            key (str): The key to be removed from the context.
-        """
-        if key in self.context:
-            del self.context[key]
-
-    def clear_context(self):
-        """
-        Clear all key-value pairs from the context.
-        """
-        self.context.clear()
+        self.observer_context.set_value(key, value)
 
     def __str__(self):
         """
@@ -60,4 +36,4 @@ class ContextObserver:
         Returns:
             str: A string representation of the context dictionary.
         """
-        return str(self.context)
+        return str(self.observer_context)

--- a/semantic_framework/context_operations/context_types.py
+++ b/semantic_framework/context_operations/context_types.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Dict, Optional
 
 
 class ContextType:
@@ -9,18 +9,18 @@ class ContextType:
     information, facilitating access and updates to context data.
 
     Attributes:
-        context_container (dict): A dictionary that stores key-value pairs representing
+        _context_container (dict): A dictionary that stores key-value pairs representing
                      the context data.
     """
 
-    def __init__(self):
+    def __init__(self, context_dict: Optional[Dict] = None):
         """
         Initialize an empty context.
 
         The context is represented by an internal dictionary that stores
         all key-value pairs.
         """
-        self.context_container = {}
+        self._context_container = {} if context_dict is None else context_dict
 
     def get_value(self, key: str) -> Any:
         """
@@ -33,7 +33,7 @@ class ContextType:
             Any: The value corresponding to the key, or None if the key
                  does not exist.
         """
-        return self.context_container.get(key)
+        return self._context_container.get(key)
 
     def set_value(self, key: str, value: Any):
         """
@@ -46,7 +46,7 @@ class ContextType:
         Returns:
             None
         """
-        self.context_container[key] = value
+        self._context_container[key] = value
 
     def delete_value(self, key: str):
         """
@@ -61,9 +61,9 @@ class ContextType:
         Returns:
             None
         """
-        if key not in self.context_container:
+        if key not in self._context_container:
             raise KeyError(f"Key '{key}' not found in context.")
-        del self.context_container[key]
+        del self._context_container[key]
 
     def clear(self):
         """
@@ -74,16 +74,16 @@ class ContextType:
         Returns:
             None
         """
-        self.context_container.clear()
+        self._context_container.clear()
 
-    def values(self) -> List[str]:
+    def keys(self) -> List[str]:
         """
         Retrieve all keys in the context.
 
         Returns:
             list: A list of all keys currently stored in the context.
         """
-        return list(self.context_container.keys())
+        return list(self._context_container.keys())
 
     def values(self) -> List[Any]:
         """
@@ -92,7 +92,7 @@ class ContextType:
         Returns:
             list: A list of all values currently stored in the context.
         """
-        return list(self.context_container.values())
+        return list(self._context_container.values())
 
     def items(self) -> List[Tuple[str, Any]]:
         """
@@ -102,7 +102,7 @@ class ContextType:
             list: A list of tuples, where each tuple contains a key and
                   its corresponding value.
         """
-        return list(self.context_container.items())
+        return list(self._context_container.items())
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}(context_container={self.context_container})"
+        return f"{self.__class__.__name__}(context={self._context_container})"

--- a/semantic_framework/data_operations/data_operations.py
+++ b/semantic_framework/data_operations/data_operations.py
@@ -117,7 +117,10 @@ class DataAlgorithm(BaseDataOperation):
             key (str): The key associated with the context update.
             value (Any): The value to update in the context.
         """
-        self.context_observer.context[key] = value
+        if key not in self.context_keys():
+            raise KeyError(f"Invalid context key '{key}' for {self.__class__.__name__}")
+        if self.context_observer:
+            self.context_observer.observer_context.set_value(key, value)
 
     def __init__(self, context_observer: Optional[ContextObserver] = None):
         """
@@ -127,6 +130,25 @@ class DataAlgorithm(BaseDataOperation):
             context_observer (ContextObserver): An observer for managing context updates.
         """
         self.context_observer = context_observer
+
+    def context_keys(self) -> List[str]:
+        """
+        Retrieve the list of valid context keys for the algorithm.
+
+        This method defines the context keys that the algorithm can update
+        during its execution. Subclasses need to implement this method to provide
+        a list of keys that are relevant to their specific functionality.
+
+        Returns:
+            List[str]: A list of strings representing valid context keys.
+
+
+        Example:
+            For an algorithm that generates a 'status' key and an 'error_count' key
+            in the context, this method should return:
+            ["status", "error_count"]
+        """
+        return []
 
     def __str__(self):
         return f"{self.__class__.__name__}"

--- a/tests/test_audio_pipeline.py
+++ b/tests/test_audio_pipeline.py
@@ -9,6 +9,7 @@ from semantic_framework.payload_operations import Pipeline
 from test_audio_algorithm import (
     SingleChannelAudioMultiplyAlgorithm,
     DualChannelAudioMultiplyAlgorithm,
+    SingleChannelMockDataProbe,
 )
 
 
@@ -36,6 +37,13 @@ def test_pipeline_execution(single_channel_audio_data):
             "operation": SingleChannelAudioMultiplyAlgorithm,
             "parameters": {"factor": 0.5},
         },
+        {
+            "operation": SingleChannelMockDataProbe,
+        },
+        {
+            "operation": SingleChannelMockDataProbe,
+            "context_keyword": "mock_keyword",
+        },
     ]
 
     # Initialize the pipeline
@@ -50,8 +58,15 @@ def test_pipeline_execution(single_channel_audio_data):
         output_data.data, single_channel_audio_data.data * 2.0 * 0.5
     )
 
-    # Inspect the pipeline
     print("\n")
+    print("=========================Pipeline context output=========================")
+    print(output_context)
+    assert "mock_keyword" in output_context.keys()
+    # Retrieve data collected by probes
+    print("=========================Pipeline probed data=========================")
+    print(pipeline.get_probe_results())
+    assert "mock_keyword" in output_context.keys()
+    # Inspect the pipeline
     print(
         "==============================Pipeline inspection=============================="
     )


### PR DESCRIPTION
- add method `get_probe_results()` to Pipelines
- Adapt node processging strategy for AlgorithmNode and probe nodes.
- Consistent use of ContextType in all payload operations
- Data algorithms must register context keys to be able to notify context update
- Add test for probe nodes: ProbeContextInjectorNode and ProbeResultCollectorNode