### PR TITLE
Add AlgorithmTopologyFactory and a quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,130 @@ Utility tools to streamline execution, monitoring, and debugging of data pipelin
 
 This project is licensed under the MIT License.
 
+
+
+---
+
+## Appendix: Getting Started
+
+This short guide helps you **jump right in** with a minimal example showcasing the **Semantic Framework’s** modular design. We’ll create and process a simple **string literal** rather than dealing with more complex domains like audio or images.
+
+
+```python
+#########################
+# Step 1: Define StringLiteralDataType
+#########################
+from semantic_framework.data_types import BaseDataType
+
+
+class StringLiteralDataType(BaseDataType):
+    """
+    Represents a simple string literal data type.
+
+    This class encapsulates a Python string, ensuring type consistency
+    and providing a base for operations on string data.
+    """
+
+    def __init__(self, data: str):
+        """
+        Initialize the StringLiteralDataType with the provided string.
+
+        Args:
+            data (str): The string data to encapsulate.
+        """
+        super().__init__(data)
+
+    def validate(self, data):
+        """
+        Validate that the provided data is a string literal.
+
+        Args:
+            data: The value to validate.
+        """
+        assert isinstance(data, str), "Data must be a string."
+
+
+#########################
+# Step 2: Create a Specialized StringLiteralAlgorithm Using AlgorithmTopologyFactory
+#########################
+from semantic_framework.data_operations import AlgorithmTopologyFactory
+
+# Dynamically create a base algorithm class for (StringLiteralDataType -> StringLiteralDataType)
+StringLiteralAlgorithm = AlgorithmTopologyFactory.create_algorithm(
+    input_type=StringLiteralDataType,
+    output_type=StringLiteralDataType,
+    class_name="StringLiteralAlgorithm",
+)
+
+
+#########################
+# Step 3: Define HelloOperation (Extending StringLiteralAlgorithm)
+#########################
+class HelloOperation(StringLiteralAlgorithm):
+    """
+    A simple operation that modifies the input string to greet the inout
+    and returns the updated value as a new StringLiteralDataType.
+    """
+
+    def _operation(self, data: StringLiteralDataType) -> StringLiteralDataType:
+        """
+        Prepends "Hello, " to the input string and returns it as a new StringLiteralDataType.
+
+        Args:
+            data (StringLiteralDataType): The input data containing a Python string.
+
+        Returns:
+            StringLiteralDataType: The updated data containing the greeting.
+        """
+        hello_data = f"Hello, {data.data}"
+        return StringLiteralDataType(hello_data)
+
+
+#########################
+# Step 4: Create a Pipeline Configuration Using HelloOperation
+#########################
+node_configurations = [
+    {
+        "operation": HelloOperation,
+        "parameters": {},  # No extra parameters needed
+    },
+]
+
+
+#########################
+# Step 5: Instantiate and Use the Pipeline
+#########################
+from semantic_framework.payload_operations import Pipeline
+
+if __name__ == "__main__":
+    # 1. Initialize the minimal pipeline with our node configurations
+    pipeline = Pipeline(node_configurations)
+
+    # 2. Create a StringLiteralDataType object
+    input_data = StringLiteralDataType("World!")
+
+    # 3. Run the pipeline
+    output_data, _ = pipeline.process(input_data, {})
+
+    # 4. Print final result
+    print("Pipeline completed. Final output:", output_data.data)
+```
+
+---
+
+## Summary
+
+In these five simple steps, you’ve:
+
+1. **Created** a custom data type for strings (`StringLiteralDataType`).
+2. **Leveraged** the built-in `AlgorithmTopologyFactory` to generate a `StringLiteralAlgorithm`.
+3. **Extended** that generic algorithm to define a specific operation (`HelloOperation`).
+4. **Built** a **node configuration** referencing `HelloOperation`.
+5. **Instantiated** a minimal pipeline and **executed** it, confirming everything works.
+
+This approach shows how easy it is to **scale** from a “Hello World” scenario to more complex data transformations—just define new data types, create operations through the **factory**, and configure the pipeline. Once comfortable, you can **explore** domain-specific modules (audio, image, text, etc.) and advanced features like context observers or parallel execution.
+
+
 ---
 
 ## Acknowledgments

--- a/semantic_framework/data_operations/data_operations.py
+++ b/semantic_framework/data_operations/data_operations.py
@@ -162,3 +162,40 @@ class DataProbe(BaseDataOperation):
     """
 
     pass
+
+
+class AlgorithmTopologyFactory:
+    """
+    A factory that creates algorithm classes for specific (input, output) data-type pairs.
+    """
+
+    @classmethod
+    def create_algorithm(cls, input_type, output_type, class_name="GeneratedAlgorithm"):
+        """
+        Dynamically creates a subclass of DataAlgorithm that expects `input_type`
+        as input and produces `output_type` as output.
+
+        Args:
+            input_type (type): The expected input data type (subclass of BaseDataType).
+            output_type (type): The output data type (subclass of BaseDataType).
+            class_name (str): The name to give the generated class.
+
+        Returns:
+            type: A new subclass of DataAlgorithm with the specified I/O data types.
+        """
+
+        # Define a dictionary of class-level methods for the new type
+        methods = {}
+
+        def input_data_type_method(self_or_cls):
+            return input_type
+
+        def output_data_type_method(self_or_cls):
+            return output_type
+
+        methods["input_data_type"] = classmethod(input_data_type_method)
+        methods["output_data_type"] = classmethod(output_data_type_method)
+
+        # Create a new type that extends DataAlgorithm
+        generated_class = type(class_name, (DataAlgorithm,), methods)
+        return generated_class

--- a/tests/test_string_specialization.py
+++ b/tests/test_string_specialization.py
@@ -1,0 +1,114 @@
+#########################
+# Step 1: Define StringLiteralDataType
+#########################
+from semantic_framework.data_types import BaseDataType
+
+
+class StringLiteralDataType(BaseDataType):
+    """
+    Represents a simple string literal data type.
+
+    This class encapsulates a Python string, ensuring type consistency
+    and providing a base for operations on string data.
+    """
+
+    def __init__(self, data: str):
+        """
+        Initialize the StringLiteralDataType with the provided string.
+
+        Args:
+            data (str): The string data to encapsulate.
+        """
+        super().__init__(data)
+
+    def validate(self, data):
+        """
+        Validate that the provided data is a string literal.
+
+        Args:
+            data: The value to validate.
+        """
+        assert isinstance(data, str), "Data must be a string."
+
+
+#########################
+# Step 2: Create a Specialized StringLiteralAlgorithm Using AlgorithmTopologyFactory
+#########################
+from semantic_framework.data_operations import AlgorithmTopologyFactory
+
+# Dynamically create a base algorithm class for (StringLiteralDataType -> StringLiteralDataType)
+StringLiteralAlgorithm = AlgorithmTopologyFactory.create_algorithm(
+    input_type=StringLiteralDataType,
+    output_type=StringLiteralDataType,
+    class_name="StringLiteralAlgorithm",
+)
+
+
+#########################
+# Step 3: Define HelloOperation (Extending StringLiteralAlgorithm)
+#########################
+class HelloOperation(StringLiteralAlgorithm):
+    """
+    A simple operation that modifies the input string to greet the inout
+    and returns the updated value as a new StringLiteralDataType.
+    """
+
+    def _operation(self, data: StringLiteralDataType) -> StringLiteralDataType:
+        """
+        Prepends "Hello, " to the input string and returns it as a new StringLiteralDataType.
+
+        Args:
+            data (StringLiteralDataType): The input data containing a Python string.
+
+        Returns:
+            StringLiteralDataType: The updated data containing the greeting.
+        """
+        hello_data = f"Hello, {data.data}"
+        return StringLiteralDataType(hello_data)
+
+
+#########################
+# Step 4: Create a Pipeline Configuration Using HelloOperation
+#########################
+node_configurations = [
+    {
+        "operation": HelloOperation,
+        "parameters": {},  # No extra parameters needed
+    },
+]
+
+
+#########################
+# Step 5: Instantiate and Use the Pipeline
+#########################
+from semantic_framework.payload_operations import Pipeline
+
+if __name__ == "__main__":
+    # 1. Initialize the minimal pipeline with our node configurations
+    pipeline = Pipeline(node_configurations)
+
+    # 2. Create a StringLiteralDataType object
+    input_data = StringLiteralDataType("World!")
+
+    # 3. Run the pipeline
+    output_data, _ = pipeline.process(input_data, {})
+
+    # 4. Print final result
+    print("Pipeline completed. Final output:", output_data.data)
+
+
+def test_string_specialization():
+    # 1. Initialize the pipeline with our node configurations
+    pipeline = Pipeline(node_configurations)
+
+    # 2. Create a StringLiteralDataType object
+    input_data = StringLiteralDataType("World!")
+
+    # 3. Run the pipeline
+    output_data, _ = pipeline.process(input_data, {})
+
+    # 4. Print final result
+    print("Pipeline completed. Final output:", output_data.data)
+
+    # Check that the output matches the expected greeting
+    assert output_data.data == "Hello, World!"


### PR DESCRIPTION
- add `AlgorithmTopologyFactory`: A factory that creates algorithm classes for specific (input, output) data-type pairs.
- add quick start guide to Readme